### PR TITLE
Add tone vocabulary blocks to vocabulary list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1223,6 +1223,600 @@
           },
         ],
       },
+      tools: {
+        'step-by-step': [
+          {
+            term: 'Sequential',
+            easyExplanation: 'following one step after another.',
+            examples: [
+              'Teach me in a sequential order, laying out each step clearly.',
+              'Structure your guidance sequentially so I can follow the process without confusion.',
+            ],
+          },
+          {
+            term: 'Methodical',
+            easyExplanation: 'careful and systematic.',
+            examples: [
+              'Use a methodical approach that shows every detail in the process.',
+              'Provide methodical instructions so nothing important is skipped.',
+            ],
+          },
+          {
+            term: 'Incremental',
+            easyExplanation: 'building up little by little.',
+            examples: [
+              'Introduce topics in an incremental way, adding complexity gradually.',
+              'Use incremental steps so that I gain confidence as each part builds on the last.',
+            ],
+          },
+          {
+            term: 'Linear',
+            easyExplanation: 'moving straight forward without skipping steps.',
+            examples: [
+              'Explain subjects in a linear sequence to maintain clarity.',
+              'Give linear instructions so I know which step comes next.',
+            ],
+          },
+          {
+            term: 'Clear',
+            easyExplanation: 'easy to understand and not confusing.',
+            examples: [
+              'Ensure your step-by-step explanations are clear and straightforward.',
+              'Provide clear guidance that removes ambiguity at each stage.',
+            ],
+          },
+        ],
+        'practice-quiz': [
+          {
+            term: 'Interactive',
+            easyExplanation: 'involving active participation.',
+            examples: [
+              'Make use of interactive questions to check my understanding.',
+              'Use an interactive style with mini quizzes so I can test myself.',
+            ],
+          },
+          {
+            term: 'Self-check',
+            easyExplanation: 'allowing me to verify my own progress.',
+            examples: [
+              'Include self-check questions that let me see how well I’m doing.',
+              'Design self-check prompts so I can measure my understanding as I go.',
+            ],
+          },
+          {
+            term: 'Reinforcing',
+            easyExplanation: 'strengthening what I’ve learned.',
+            examples: [
+              'Use reinforcing questions to help solidify my knowledge.',
+              'Add reinforcing activities to ensure I remember important details.',
+            ],
+          },
+          {
+            term: 'Assessment-based',
+            easyExplanation: 'focused on measuring progress.',
+            examples: [
+              'Give assessment-based practice to evaluate what I’ve learned.',
+              'Create assessment-based prompts that provide feedback on my learning.',
+            ],
+          },
+          {
+            term: 'Feedback-driven',
+            easyExplanation: 'providing responses that guide improvement.',
+            examples: [
+              'Offer feedback-driven quizzes so I know how to improve.',
+              'Use feedback-driven prompts to guide me when I get questions wrong.',
+            ],
+          },
+        ],
+        'creative-task': [
+          {
+            term: 'Inventive',
+            easyExplanation: 'original and imaginative.',
+            examples: [
+              'Encourage me to think in an inventive way by creating my own examples.',
+              'Use inventive tasks that let me design or build something related to the subject.',
+            ],
+          },
+          {
+            term: 'Artistic',
+            easyExplanation: 'relating to art and creativity.',
+            examples: [
+              'Suggest artistic activities to help me express ideas creatively.',
+              'Use artistic tasks like drawing or designing to explore the topic.',
+            ],
+          },
+          {
+            term: 'Exploratory',
+            easyExplanation: 'involving investigation and discovery.',
+            examples: [
+              'Provide exploratory projects where I can discover ideas on my own.',
+              'Use exploratory assignments that let me experiment and find new connections.',
+            ],
+          },
+          {
+            term: 'Original',
+            easyExplanation: 'new and not copied.',
+            examples: [
+              'Ask for original work that reflects my own thinking.',
+              'Encourage original creations so I can apply knowledge in new ways.',
+            ],
+          },
+          {
+            term: 'Expressive',
+            easyExplanation: 'showing thoughts or feelings vividly.',
+            examples: [
+              'Use expressive projects that let me communicate my understanding clearly.',
+              'Provide expressive tasks like storytelling or presentations to convey ideas.',
+            ],
+          },
+        ],
+        'big-picture-first': [
+          {
+            term: 'Overview',
+            easyExplanation: 'broad summary of the main parts.',
+            examples: [
+              'Start with an overview to give me the main points before details.',
+              'Provide an overview so I can see how all the concepts fit together.',
+            ],
+          },
+          {
+            term: 'Conceptual',
+            easyExplanation: 'focused on ideas and theories.',
+            examples: [
+              'Use a conceptual introduction to outline the main ideas.',
+              'Begin with conceptual explanations before diving into specifics.',
+            ],
+          },
+          {
+            term: 'Macro-level',
+            easyExplanation: 'looking at the whole system.',
+            examples: [
+              'Give macro-level insights so I understand the overall structure.',
+              'Explain the subject at a macro-level first to orient me.',
+            ],
+          },
+          {
+            term: 'Framework-oriented',
+            easyExplanation: 'organized around a structure or model.',
+            examples: [
+              'Introduce the framework that underlies the topic before the details.',
+              'Use a framework-oriented approach to explain the big picture.',
+            ],
+          },
+          {
+            term: 'Broad',
+            easyExplanation: 'covering many areas rather than details.',
+            examples: [
+              'Start with broad concepts to prepare me for the specifics.',
+              'Provide broad explanations before narrowing down to details.',
+            ],
+          },
+        ],
+        'worked-example-try-it': [
+          {
+            term: 'Guided',
+            easyExplanation: 'led step by step.',
+            examples: [
+              'Show me a guided example before I try a similar problem.',
+              'Use a guided approach that leads me through an example first.',
+            ],
+          },
+          {
+            term: 'Example-led',
+            easyExplanation: 'starting with a detailed example.',
+            examples: [
+              'Begin with an example-led explanation to show how it’s done.',
+              'Use example-led demonstrations so I can model my own work after them.',
+            ],
+          },
+          {
+            term: 'Demonstrative',
+            easyExplanation: 'showing clearly how something works.',
+            examples: [
+              'Provide demonstrative examples that show each step clearly.',
+              'Give demonstrative guidance before letting me attempt it on my own.',
+            ],
+          },
+          {
+            term: 'Model-based',
+            easyExplanation: 'using models or patterns to illustrate.',
+            examples: [
+              'Use model-based examples that I can imitate when solving problems.',
+              'Offer model-based solutions so I can understand the structure.',
+            ],
+          },
+          {
+            term: 'Practice-after',
+            easyExplanation: 'trying it after seeing it done.',
+            examples: [
+              'Allow me to practice-after by working on a similar example.',
+              'Encourage practice-after demonstrations to reinforce what I just learned.',
+            ],
+          },
+        ],
+      },
+      energy: {
+        sports: [
+          {
+            term: 'Competitive',
+            easyExplanation: 'involving a desire to win or be the best.',
+            examples: [
+              'Relate the topic to competitive sports situations to motivate me.',
+              'Use competitive sports analogies to show how strategies apply.',
+            ],
+          },
+          {
+            term: 'Team-based',
+            easyExplanation: 'involving cooperation with others.',
+            examples: [
+              'Use team-based sports examples to illustrate the importance of collaboration.',
+              'Explain concepts using team-based situations where cooperation leads to success.',
+            ],
+          },
+          {
+            term: 'Physically engaging',
+            easyExplanation: 'requiring physical activity and energy.',
+            examples: [
+              'Connect lessons to physically engaging sports to keep my interest.',
+              'Use physically engaging sports scenarios to make the material dynamic.',
+            ],
+          },
+          {
+            term: 'Strategic',
+            easyExplanation: 'requiring planning and tactics.',
+            examples: [
+              'Link the subject to strategic decision-making like in sports.',
+              'Use strategic sports examples to show how planning is important.',
+            ],
+          },
+          {
+            term: 'Endurance',
+            easyExplanation: 'persistence and staying power over time.',
+            examples: [
+              'Highlight endurance in sports to encourage persistence in learning.',
+              'Use endurance-focused sports to teach about long-term effort in studying.',
+            ],
+          },
+        ],
+        music: [
+          {
+            term: 'Rhythmic',
+            easyExplanation: 'relating to rhythm or beat.',
+            examples: [
+              'Incorporate rhythmic examples from music to illustrate patterns.',
+              'Use rhythmic comparisons to show how topics flow like music.',
+            ],
+          },
+          {
+            term: 'Melodic',
+            easyExplanation: 'relating to melody or tune.',
+            examples: [
+              'Explain ideas using melodic analogies from songs.',
+              'Use melodic references to help me remember concepts.',
+            ],
+          },
+          {
+            term: 'Harmonious',
+            easyExplanation: 'pleasant combination of different elements.',
+            examples: [
+              'Show how ideas can be harmonious like chords in music.',
+              'Use harmonious examples to illustrate how concepts work together.',
+            ],
+          },
+          {
+            term: 'Performance-related',
+            easyExplanation: 'connected to performing music.',
+            examples: [
+              'Use performance-related stories to highlight skills like practice and stage presence.',
+              'Relate learning to performance-related aspects such as rehearsing and improving.',
+            ],
+          },
+          {
+            term: 'Creative',
+            easyExplanation: 'inventive and artistic.',
+            examples: [
+              'Tie the topic to creative music-making to inspire interest.',
+              'Use creative music metaphors to explain difficult concepts.',
+            ],
+          },
+        ],
+        gaming: [
+          {
+            term: 'Interactive',
+            easyExplanation: 'involving active participation.',
+            examples: [
+              'Relate ideas to interactive gaming elements to increase engagement.',
+              'Use interactive gaming scenarios to demonstrate decision-making.',
+            ],
+          },
+          {
+            term: 'Level-based',
+            easyExplanation: 'progressing through stages or levels.',
+            examples: [
+              'Explain learning as level-based advancement like in games.',
+              'Use level-based examples to show how difficulty increases over time.',
+            ],
+          },
+          {
+            term: 'Strategy-driven',
+            easyExplanation: 'requiring planning and tactics.',
+            examples: [
+              'Use strategy-driven gaming analogies to show how careful planning leads to success.',
+              'Relate complex topics to strategy-driven games where choices matter.',
+            ],
+          },
+          {
+            term: 'Reward-focused',
+            easyExplanation: 'motivated by incentives or achievements.',
+            examples: [
+              'Explain how reward-focused gaming keeps players motivated and connect it to studying.',
+              'Use reward-focused examples like points or achievements to illustrate progress.',
+            ],
+          },
+          {
+            term: 'Immersive',
+            easyExplanation: 'deeply involving and absorbing.',
+            examples: [
+              'Use immersive game stories to capture my attention while learning.',
+              'Relate immersive gaming experiences to help me stay engaged with the topic.',
+            ],
+          },
+        ],
+        cooking: [
+          {
+            term: 'Recipe-based',
+            easyExplanation: 'following a set of instructions.',
+            examples: [
+              'Connect lessons to recipe-based cooking to show step-by-step processes.',
+              'Use recipe-based analogies to demonstrate following instructions carefully.',
+            ],
+          },
+          {
+            term: 'Measured',
+            easyExplanation: 'using precise amounts.',
+            examples: [
+              'Explain concepts using measured ingredients to highlight accuracy.',
+              'Use measured cooking examples to show the importance of precision.',
+            ],
+          },
+          {
+            term: 'Creative culinary',
+            easyExplanation: 'encouraging inventive cooking.',
+            examples: [
+              'Relate topics to creative culinary experiments to spark interest.',
+              'Use creative culinary scenarios to illustrate experimenting with ideas.',
+            ],
+          },
+          {
+            term: 'Step-by-step',
+            easyExplanation: 'progressing one stage at a time.',
+            examples: [
+              'Use step-by-step cooking processes to mirror how to learn new topics.',
+              'Show me step-by-step recipes to parallel learning sequences.',
+            ],
+          },
+          {
+            term: 'Sensory',
+            easyExplanation: 'involving senses like taste and smell.',
+            examples: [
+              'Explain ideas with sensory cooking experiences to make learning vivid.',
+              'Use sensory descriptions from cooking to help me remember concepts.',
+            ],
+          },
+        ],
+        'future-skills': [
+          {
+            term: 'Career-building',
+            easyExplanation: 'helping to build a professional life.',
+            examples: [
+              'Relate learning to career-building skills I will need later.',
+              'Use career-building examples to illustrate why the topic matters for jobs.',
+            ],
+          },
+          {
+            term: 'Forward-looking',
+            easyExplanation: 'anticipating future developments.',
+            examples: [
+              'Use forward-looking scenarios to show how knowledge is preparing me for the future.',
+              'Explain topics in a forward-looking way to motivate long-term learning.',
+            ],
+          },
+          {
+            term: 'Skill-oriented',
+            easyExplanation: 'focused on developing abilities.',
+            examples: [
+              'Connect lessons to skill-oriented practice to improve my abilities.',
+              'Use skill-oriented tasks to show how knowledge builds practical skills.',
+            ],
+          },
+          {
+            term: 'Employability-focused',
+            easyExplanation: 'aiming to improve job prospects.',
+            examples: [
+              'Explain how the subject is employability-focused to help me get future jobs.',
+              'Use employability-focused examples to highlight real-world benefits.',
+            ],
+          },
+          {
+            term: 'Goal-oriented',
+            easyExplanation: 'directed towards achieving specific goals.',
+            examples: [
+              'Frame your guidance as goal-oriented to help me achieve learning objectives.',
+              'Use goal-oriented explanations to keep me focused on outcomes.',
+            ],
+          },
+        ],
+      },
+      gear: {
+        'easy-to-hard': [
+          {
+            term: 'Progressive',
+            easyExplanation: 'advancing gradually from simple to complex.',
+            examples: [
+              'Use a progressive pace to build my understanding from easy to complex.',
+              'Take a progressive approach so each new concept builds on the last.',
+            ],
+          },
+          {
+            term: 'Gradual',
+            easyExplanation: 'changing slowly over time.',
+            examples: [
+              'Increase difficulty in a gradual way so I don’t feel overwhelmed.',
+              'Adopt a gradual pace to let me adapt to harder material step by step.',
+            ],
+          },
+          {
+            term: 'Scaffolded',
+            easyExplanation: 'supported by layers of helpful steps.',
+            examples: [
+              'Present information in a scaffolded manner with plenty of support.',
+              'Use scaffolded explanations to help me climb from basic to advanced ideas.',
+            ],
+          },
+          {
+            term: 'Confidence-building',
+            easyExplanation: 'helping to increase self-belief.',
+            examples: [
+              'Provide confidence-building tasks that start easy and become challenging.',
+              'Design confidence-building lessons so my self-belief grows with progress.',
+            ],
+          },
+          {
+            term: 'Incremental difficulty',
+            easyExplanation: 'increasing challenge bit by bit.',
+            examples: [
+              'Use incremental difficulty to help me adjust to more complex topics.',
+              'Keep the challenge at incremental difficulty so I gain skills steadily.',
+            ],
+          },
+        ],
+        'hard-to-easy': [
+          {
+            term: 'Reverse',
+            easyExplanation: 'turning the usual order around.',
+            examples: [
+              'Start with a reverse approach by introducing the hardest ideas first.',
+              'Use a reverse sequence so the toughest parts come before simpler ones.',
+            ],
+          },
+          {
+            term: 'Simplifying',
+            easyExplanation: 'making something easier to understand.',
+            examples: [
+              'After tackling hard concepts, focus on simplifying them for clarity.',
+              'Apply simplifying steps to break down complex ideas once the challenge is clear.',
+            ],
+          },
+          {
+            term: 'Deconstructive',
+            easyExplanation: 'taking apart complex ideas.',
+            examples: [
+              'Use a deconstructive method to break hard concepts into easier pieces.',
+              'Adopt a deconstructive style that takes complex ideas apart after introducing them.',
+            ],
+          },
+          {
+            term: 'Front-loaded challenge',
+            easyExplanation: 'starting with high difficulty.',
+            examples: [
+              'Employ a front-loaded challenge to introduce difficult material right away.',
+              'Let me experience a front-loaded challenge before revisiting simpler parts.',
+            ],
+          },
+          {
+            term: 'Step-down',
+            easyExplanation: 'reducing difficulty step by step.',
+            examples: [
+              'Follow up with a step-down sequence to ease into easier material.',
+              'Use a step-down approach so the material becomes more approachable after the peak.',
+            ],
+          },
+        ],
+        'quick-wins': [
+          {
+            term: 'Bite-sized',
+            easyExplanation: 'small and manageable.',
+            examples: [
+              'Provide bite-sized tasks that I can complete quickly.',
+              'Use bite-sized challenges so I see quick results and stay motivated.',
+            ],
+          },
+          {
+            term: 'Rewarding',
+            easyExplanation: 'giving a sense of achievement.',
+            examples: [
+              'Offer rewarding tasks so I feel a sense of accomplishment.',
+              'Keep activities rewarding to encourage continued effort.',
+            ],
+          },
+          {
+            term: 'Motivating',
+            easyExplanation: 'giving energy to keep going.',
+            examples: [
+              'Use motivating exercises to boost my enthusiasm.',
+              'Design motivating mini-goals to keep me engaged.',
+            ],
+          },
+          {
+            term: 'Short bursts',
+            easyExplanation: 'small periods of focused activity.',
+            examples: [
+              'Plan short bursts of learning that fit into my schedule.',
+              'Incorporate short bursts of practice to maintain my focus.',
+            ],
+          },
+          {
+            term: 'Momentum-building',
+            easyExplanation: 'creating a sense of forward movement.',
+            examples: [
+              'Use momentum-building tasks to keep my progress going.',
+              'Ensure the work is momentum-building so I feel I’m getting somewhere.',
+            ],
+          },
+        ],
+        'deep-dives': [
+          {
+            term: 'Comprehensive',
+            easyExplanation: 'covering a lot of detail.',
+            examples: [
+              'Provide comprehensive explanations that explore all aspects of the topic.',
+              'Use comprehensive lessons to give me a full understanding.',
+            ],
+          },
+          {
+            term: 'In-depth',
+            easyExplanation: 'going deeply into a subject.',
+            examples: [
+              'Take an in-depth approach that explores complex details.',
+              'Explain topics in-depth so I grasp the intricacies.',
+            ],
+          },
+          {
+            term: 'Thorough',
+            easyExplanation: 'complete and detailed.',
+            examples: [
+              'Give thorough coverage of each concept so nothing is missed.',
+              'Use thorough explanations to ensure complete understanding.',
+            ],
+          },
+          {
+            term: 'Analytical',
+            easyExplanation: 'carefully examining parts and reasons.',
+            examples: [
+              'Use an analytical approach to break down and examine the parts of a topic.',
+              'Encourage analytical thinking so I learn to question and explore deeper.',
+            ],
+          },
+          {
+            term: 'Immersive',
+            easyExplanation: 'fully absorbing and engaging.',
+            examples: [
+              'Create immersive experiences that draw me into the subject.',
+              'Use immersive materials so I can fully engage with the ideas.',
+            ],
+          },
+        ],
+      },
     };
 
     const moduleButtons = document.querySelectorAll('[data-module-tab]');

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
     Show Navigation
   </button>
 
-  <main data-main-content class="mx-auto max-w-7xl space-y-16 px-4 py-10 pb-[30vh] md:ml-[300px]">
+  <main data-main-content class="mx-auto max-w-7xl space-y-16 px-4 py-10 pb-[30vh]">
       <section id="design" class="scroll-mt-24">
         <h2 class="text-2xl font-bold md:text-3xl">Module Customization</h2>
         <div class="mt-4 grid gap-4 md:grid-cols-2">

--- a/index.html
+++ b/index.html
@@ -357,8 +357,14 @@
           <div>
             <h3 class="text-base font-semibold text-slate-800">3. Useful Vocabulary</h3>
             <div id="vocab-panel" class="mt-3 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
-              <p class="text-sm text-slate-700">Vocabulary placeholder for <span class="font-semibold" data-active-module-label>tones</span>
-                → <span class="font-semibold" data-active-option-label>expert</span>. We'll populate this list next.</p>
+              <p class="text-sm text-slate-700" data-vocab-summary>
+                Vocabulary for <span class="font-semibold" data-active-module-label>tones</span>
+                → <span class="font-semibold" data-active-option-label>expert</span>
+              </p>
+              <p class="mt-2 text-sm text-slate-500" data-vocab-empty hidden>
+                Vocabulary entries are coming soon for this combination.
+              </p>
+              <div class="mt-4 space-y-4" data-vocab-list></div>
             </div>
           </div>
         </div>
@@ -876,10 +882,185 @@
       },
     };
 
+    const vocabularyContent = {
+      tones: {
+        expert: [
+          {
+            term: 'Precise',
+            easyExplanation: 'very exact and clear',
+            examples: [
+              'The scientist gave a precise answer to the question.',
+              'Please explain concepts in a precise way so that every detail is correct and easy to follow.',
+            ],
+          },
+          {
+            term: 'Logical',
+            easyExplanation: 'based on reason and clear thinking',
+            examples: [
+              'Her logical explanation made the problem easy to follow.',
+              'I want your explanations to be logical, showing each step in clear order.',
+            ],
+          },
+          {
+            term: 'Formal',
+            easyExplanation: 'serious and professional style',
+            examples: [
+              'He wrote a formal letter to his teacher.',
+              'Use a formal tone when teaching me, as if writing an academic explanation.',
+            ],
+          },
+          {
+            term: 'Confident',
+            easyExplanation: 'sure and certain',
+            examples: [
+              'The tutor sounded confident about the answer.',
+              'Answer in a confident tone so I can trust the information you give me.',
+            ],
+          },
+          {
+            term: 'Structured',
+            easyExplanation: 'well organized, step by step',
+            examples: [
+              'The lesson was structured with a clear beginning, middle, and end.',
+              'Give your answers in a structured way, starting from the basics and moving to advanced ideas.',
+            ],
+          },
+        ],
+        coach: [
+          {
+            term: 'Encouraging',
+            easyExplanation: 'supportive, makes you want to keep going',
+            examples: [
+              'The coach’s encouraging words helped the team try harder.',
+              'Use an encouraging tone so I feel motivated to keep studying even if I make mistakes.',
+            ],
+          },
+          {
+            term: 'Motivational',
+            easyExplanation: 'gives energy and inspiration',
+            examples: [
+              'The speaker gave a motivational talk to the students.',
+              'Be motivational by reminding me that I can succeed if I stay focused.',
+            ],
+          },
+          {
+            term: 'Direct',
+            easyExplanation: 'clear and straight to the point',
+            examples: [
+              'The teacher gave direct instructions for the project.',
+              'Please be direct in your answers so I don’t get lost in extra details.',
+            ],
+          },
+          {
+            term: 'Firm',
+            easyExplanation: 'strong and steady, not weak',
+            examples: [
+              'The coach gave a firm order to the players.',
+              'Keep a firm tone to guide me when I lose focus or get distracted.',
+            ],
+          },
+          {
+            term: 'Supportive',
+            easyExplanation: 'helps and cares for you',
+            examples: [
+              'She was very supportive when I had trouble in class.',
+              'Sound supportive so I feel safe asking questions without fear of being judged.',
+            ],
+          },
+        ],
+        'study-buddy': [
+          {
+            term: 'Casual',
+            easyExplanation: 'relaxed, everyday style',
+            examples: [
+              'He used a casual tone when talking with friends.',
+              'Use a casual style so it feels like I’m learning with a friend.',
+            ],
+          },
+          {
+            term: 'Friendly',
+            easyExplanation: 'warm and kind',
+            examples: [
+              'The tutor was friendly and easy to talk to.',
+              'Keep your answers friendly so I feel comfortable while studying.',
+            ],
+          },
+          {
+            term: 'Relaxed',
+            easyExplanation: 'calm, not too serious',
+            examples: [
+              'His relaxed voice made everyone feel comfortable.',
+              'Speak in a relaxed way to lower my stress when learning hard topics.',
+            ],
+          },
+          {
+            term: 'Approachable',
+            easyExplanation: 'easy to talk to',
+            examples: [
+              'The teacher was approachable, so students asked many questions.',
+              'Be approachable so I feel free to ask follow-up questions anytime.',
+            ],
+          },
+          {
+            term: 'Simple',
+            easyExplanation: 'easy to understand',
+            examples: [
+              'She gave a simple example to explain the idea.',
+              'Explain in a simple way, using short sentences and easy examples.',
+            ],
+          },
+        ],
+        storyteller: [
+          {
+            term: 'Imaginative',
+            easyExplanation: 'creative, full of pictures in your mind',
+            examples: [
+              'The writer used an imaginative style in the story.',
+              'Teach me in an imaginative way by using creative examples that paint a picture.',
+            ],
+          },
+          {
+            term: 'Playful',
+            easyExplanation: 'fun and light, not too serious',
+            examples: [
+              'The teacher had a playful way of explaining grammar.',
+              'Make your tone playful so learning feels fun instead of boring.',
+            ],
+          },
+          {
+            term: 'Engaging',
+            easyExplanation: 'keeps your attention, interesting',
+            examples: [
+              'The speaker’s engaging style made everyone listen.',
+              'Be engaging so I stay focused and want to continue the lesson.',
+            ],
+          },
+          {
+            term: 'Descriptive',
+            easyExplanation: 'full of details, paints a picture',
+            examples: [
+              'The author gave a descriptive account of the setting.',
+              'Give descriptive examples that help me see the idea clearly in my mind.',
+            ],
+          },
+          {
+            term: 'Expressive',
+            easyExplanation: 'shows strong feelings or emotions',
+            examples: [
+              'She told the story in an expressive way.',
+              'Use an expressive tone so I feel the importance and excitement of the lesson.',
+            ],
+          },
+        ],
+      },
+    };
+
     const moduleButtons = document.querySelectorAll('[data-module-tab]');
     const optionsContainer = document.getElementById('module-options');
     const moduleLabel = document.querySelector('[data-active-module-label]');
     const optionLabel = document.querySelector('[data-active-option-label]');
+    const vocabList = document.querySelector('[data-vocab-list]');
+    const vocabEmptyState = document.querySelector('[data-vocab-empty]');
 
     const getSavedOptionForVocabularyModule = (moduleKey) => {
       const designModuleKey = vocabularyModuleToDesignModuleMap[moduleKey];
@@ -893,10 +1074,74 @@
     let activeOption =
       getSavedOptionForVocabularyModule(activeModule) ?? modules[activeModule].options[0]?.key ?? '';
 
+    const renderVocabularyContent = () => {
+      if (!vocabList) return;
+
+      const entries = vocabularyContent[activeModule]?.[activeOption] ?? [];
+      vocabList.innerHTML = '';
+
+      if (!entries.length) {
+        if (vocabEmptyState) {
+          vocabEmptyState.removeAttribute('hidden');
+        }
+        return;
+      }
+
+      if (vocabEmptyState) {
+        vocabEmptyState.setAttribute('hidden', '');
+      }
+
+      entries.forEach((entry) => {
+        const block = document.createElement('div');
+        block.className =
+          'space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-5 text-sm text-slate-700';
+
+        const title = document.createElement('h4');
+        title.className = 'text-lg font-semibold text-slate-800';
+        title.textContent = entry.term;
+        block.appendChild(title);
+
+        const easyHeader = document.createElement('p');
+        easyHeader.className = 'text-sm font-semibold text-slate-800';
+        easyHeader.textContent = 'Easy Explanation';
+        block.appendChild(easyHeader);
+
+        const easyText = document.createElement('p');
+        easyText.textContent = entry.easyExplanation;
+        block.appendChild(easyText);
+
+        entry.examples.forEach((example, index) => {
+          const exampleWrapper = document.createElement('div');
+          exampleWrapper.className = 'space-y-1';
+
+          const exampleHeader = document.createElement('p');
+          exampleHeader.className = 'text-sm font-semibold text-slate-800';
+          exampleHeader.textContent = `Example ${index + 1}:`;
+          exampleWrapper.appendChild(exampleHeader);
+
+          const exampleText = document.createElement('p');
+          exampleText.textContent = example;
+          exampleWrapper.appendChild(exampleText);
+
+          block.appendChild(exampleWrapper);
+        });
+
+        vocabList.appendChild(block);
+      });
+    };
+
     const updateVocabularyPlaceholder = () => {
-      moduleLabel.textContent = modules[activeModule].label;
-      const currentOption = modules[activeModule].options.find((opt) => opt.key === activeOption);
-      optionLabel.textContent = currentOption ? currentOption.label : '';
+      const moduleData = modules[activeModule];
+      if (moduleLabel) {
+        moduleLabel.textContent = moduleData?.label ?? '';
+      }
+
+      const currentOption = moduleData?.options.find((opt) => opt.key === activeOption);
+      if (optionLabel) {
+        optionLabel.textContent = currentOption ? currentOption.label : '';
+      }
+
+      renderVocabularyContent();
     };
 
     const renderOptions = () => {

--- a/index.html
+++ b/index.html
@@ -1053,6 +1053,176 @@
           },
         ],
       },
+      connections: {
+        hobbies: [
+          {
+            term: 'Personalized',
+            easyExplanation: 'tailored to your favorite activities.',
+            examples: [
+              'Use examples tailored to my personalized interests like painting to make math fun.',
+              'When writing prompts, ask for personalized explanations tied to my hobbies.',
+            ],
+          },
+          {
+            term: 'Relatable',
+            easyExplanation: 'easy to relate to your own experiences.',
+            examples: [
+              'Connect new concepts in a relatable way by using stories from my hobbies.',
+              'Please make the material relatable by linking it to activities I love.',
+            ],
+          },
+          {
+            term: 'Hands-on',
+            easyExplanation: 'involving active participation and doing.',
+            examples: [
+              'Show me hands-on examples that involve my hobbies to help me understand.',
+              'Offer hands-on challenges based on my interests to keep me engaged.',
+            ],
+          },
+          {
+            term: 'Creative',
+            easyExplanation: 'encouraging imagination and original thinking.',
+            examples: [
+              'I learn better with creative explanations that use my hobbies.',
+              'Use a creative approach linked to my interests to illustrate new ideas.',
+            ],
+          },
+          {
+            term: 'Engaging',
+            easyExplanation: 'holding attention and sparking interest.',
+            examples: [
+              'Make lessons more engaging by referring to my favorite activities.',
+              'An engaging prompt should weave my hobbies into the learning process.',
+            ],
+          },
+        ],
+        'daily-life': [
+          {
+            term: 'Practical',
+            easyExplanation: 'useful and applicable to real situations.',
+            examples: [
+              'Explain concepts in a practical way by showing how they appear in daily routines.',
+              'Give practical examples from everyday life so I can see why the topic matters.',
+            ],
+          },
+          {
+            term: 'Everyday',
+            easyExplanation: 'common and part of daily routines.',
+            examples: [
+              'Provide everyday scenarios that show how this topic is used.',
+              'Use everyday tasks to illustrate the concept so I can understand it easily.',
+            ],
+          },
+          {
+            term: 'Relevant',
+            easyExplanation: 'directly connected to what is important to me.',
+            examples: [
+              'Make your examples relevant to my daily life for better understanding.',
+              'Include relevant situations from my routine to explain why this subject matters.',
+            ],
+          },
+          {
+            term: 'Familiar',
+            easyExplanation: 'something I already know or experience often.',
+            examples: [
+              'Use familiar settings like home or school in your explanations.',
+              'Present information through familiar experiences so it feels accessible.',
+            ],
+          },
+          {
+            term: 'Applicable',
+            easyExplanation: 'something that can be used in real life.',
+            examples: [
+              'Show me how these ideas are applicable to tasks I do every day.',
+              'Keep your guidance applicable to real-life situations I encounter.',
+            ],
+          },
+        ],
+        'jobs-careers': [
+          {
+            term: 'Professional',
+            easyExplanation: 'relating to a job or career.',
+            examples: [
+              'Provide professional examples that show how this knowledge is used in careers.',
+              'Explain in a professional context to help me see workplace applications.',
+            ],
+          },
+          {
+            term: 'Industry-focused',
+            easyExplanation: 'connected to specific fields or industries.',
+            examples: [
+              'Use industry-focused examples so I understand how the topic fits in the working world.',
+              'Include industry-focused scenarios to link learning with career possibilities.',
+            ],
+          },
+          {
+            term: 'Real-world',
+            easyExplanation: 'based on actual job situations.',
+            examples: [
+              'Offer real-world examples from careers to make the subject more concrete.',
+              'Draw on real-world experiences to illustrate how professionals use this knowledge.',
+            ],
+          },
+          {
+            term: 'Career-oriented',
+            easyExplanation: 'directed towards future job goals.',
+            examples: [
+              'Connect the material to career-oriented goals to show why it is valuable.',
+              'Use career-oriented explanations that highlight future employment benefits.',
+            ],
+          },
+          {
+            term: 'Future-ready',
+            easyExplanation: 'preparing for future job needs.',
+            examples: [
+              'Help me become future-ready by explaining how skills apply in emerging careers.',
+              'Provide future-ready insights so I can see where this knowledge will be useful.',
+            ],
+          },
+        ],
+        values: [
+          {
+            term: 'Ethical',
+            easyExplanation: 'concerned with doing what is right.',
+            examples: [
+              'Frame your explanations in an ethical context to show why responsible choices matter.',
+              'Discuss ethical implications when connecting the topic to my values.',
+            ],
+          },
+          {
+            term: 'Sustainable',
+            easyExplanation: 'supporting long-term health of the environment or society.',
+            examples: [
+              'Use sustainable examples to illustrate how learning can benefit the world.',
+              'Describe sustainable practices that connect with the lesson and my values.',
+            ],
+          },
+          {
+            term: 'Fair',
+            easyExplanation: 'treating everyone equally and justly.',
+            examples: [
+              'Explain concepts using fair examples to emphasize justice and equality.',
+              'Show me fair scenarios where this knowledge can promote equity.',
+            ],
+          },
+          {
+            term: 'Compassionate',
+            easyExplanation: 'showing care and empathy for others.',
+            examples: [
+              'Use compassionate examples that highlight helping others through this knowledge.',
+              'Frame your guidance in a compassionate way to inspire care for others.',
+            ],
+          },
+          {
+            term: 'Responsible',
+            easyExplanation: 'acting sensibly and being accountable.',
+            examples: [
+              'Encourage responsible use of knowledge by showing real-life cases.',
+              'Give responsible guidance so I learn to apply ideas wisely.',
+            ],
+          },
+        ],
+      },
     };
 
     const moduleButtons = document.querySelectorAll('[data-module-tab]');

--- a/index.html
+++ b/index.html
@@ -38,30 +38,53 @@
     </div>
   </header>
 
-  <div class="mx-auto grid max-w-7xl grid-cols-1 gap-6 px-4 py-10 md:grid-cols-[280px_1fr]">
-    <aside class="md:sticky md:top-28">
-      <div class="rounded-lg border border-slate-200 bg-white shadow-sm">
-        <div class="border-b border-slate-200 px-6 py-4">
-          <div class="flex items-center gap-2 text-base font-semibold text-slate-800">
-            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-              <path d="M4 4h16v16H4z" opacity="0.4"></path>
-              <path d="M8 8h8M8 12h8M8 16h5" stroke-linecap="round" stroke-linejoin="round"></path>
-            </svg>
-            Navigation
-          </div>
-        </div>
-        <div class="px-6 py-4 text-sm text-slate-700">
-          <nav class="flex flex-col gap-2">
-            <a href="#design" class="transition hover:text-slate-900 hover:underline">Module Customization</a>
-            <a href="#examples" class="transition hover:text-slate-900 hover:underline">Example Prompts</a>
-            <a href="#guiding" class="transition hover:text-slate-900 hover:underline">Guiding Questions</a>
-            <a href="#vocab" class="transition hover:text-slate-900 hover:underline">Vocabulary List</a>
-          </nav>
-        </div>
+  <aside
+    id="floating-nav"
+    class="fixed left-4 top-28 z-40 w-64 rounded-lg border border-slate-200 bg-white shadow-lg"
+    aria-label="Page navigation"
+  >
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+      <div class="flex items-center gap-2 text-base font-semibold text-slate-800">
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="M4 4h16v16H4z" opacity="0.4"></path>
+          <path d="M8 8h8M8 12h8M8 16h5" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+        Navigation
       </div>
-    </aside>
+      <button
+        type="button"
+        class="rounded-full border border-slate-200 p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+        aria-expanded="true"
+        aria-controls="floating-nav"
+        data-nav-collapse
+      >
+        <span class="sr-only">Collapse navigation</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="m7 9 5 5 5-5" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </button>
+    </div>
+    <div class="px-6 py-4 text-sm text-slate-700">
+      <nav class="flex flex-col gap-2">
+        <a href="#design" class="transition hover:text-slate-900 hover:underline">Module Customization</a>
+        <a href="#examples" class="transition hover:text-slate-900 hover:underline">Example Prompts</a>
+        <a href="#guiding" class="transition hover:text-slate-900 hover:underline">Guiding Questions</a>
+        <a href="#vocab" class="transition hover:text-slate-900 hover:underline">Vocabulary List</a>
+      </nav>
+    </div>
+  </aside>
 
-    <main class="space-y-16">
+  <button
+    type="button"
+    id="nav-expand"
+    class="fixed left-4 top-28 z-30 hidden rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 shadow"
+    aria-controls="floating-nav"
+    aria-expanded="false"
+  >
+    Show Navigation
+  </button>
+
+  <main data-main-content class="mx-auto max-w-7xl space-y-16 px-4 py-10 pb-[30vh] md:ml-[300px]">
       <section id="design" class="scroll-mt-24">
         <h2 class="text-2xl font-bold md:text-3xl">Module Customization</h2>
         <div class="mt-4 grid gap-4 md:grid-cols-2">
@@ -370,7 +393,55 @@
         </div>
       </section>
     </main>
+
+  <div
+    id="prompt-editor"
+    class="fixed bottom-4 left-4 right-4 z-30 flex h-[25vh] flex-col rounded-xl border border-slate-200 bg-white shadow-xl"
+  >
+    <div class="flex items-center justify-between border-b border-slate-200 px-5 py-3">
+      <div class="text-base font-semibold text-slate-800">Prompt Editor</div>
+      <button
+        type="button"
+        class="rounded-full border border-slate-200 p-1 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700"
+        aria-controls="prompt-editor"
+        aria-expanded="true"
+        data-prompt-collapse
+      >
+        <span class="sr-only">Collapse prompt editor</span>
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <path d="m7 9 5 5 5-5" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+      </button>
+    </div>
+    <div class="flex flex-1 min-h-0 flex-col gap-3 p-5">
+      <label for="prompt-input" class="text-sm font-medium text-slate-700">Your prompt</label>
+      <textarea
+        id="prompt-input"
+        data-prompt-input
+        class="flex-1 resize-none overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 p-3 text-sm text-slate-800 outline-none transition focus:border-slate-400 focus:bg-white"
+        placeholder="Draft or edit your prompt here..."
+      ></textarea>
+      <div class="flex justify-end gap-2">
+        <button
+          type="button"
+          data-copy-prompt
+          class="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+        >
+          Copy Prompt
+        </button>
+      </div>
+    </div>
   </div>
+
+  <button
+    type="button"
+    id="prompt-expand"
+    class="fixed bottom-4 left-1/2 z-20 hidden -translate-x-1/2 rounded-full border border-slate-200 bg-white px-4 py-2 text-xs font-medium text-slate-700 shadow"
+    aria-controls="prompt-editor"
+    aria-expanded="false"
+  >
+    Show Prompt Editor
+  </button>
 
   <script>
     // Module illustration placeholders (update paths as needed)
@@ -829,6 +900,15 @@
       tools: 'tools-pack',
       energy: 'energy-source',
       gear: 'gear-settings',
+    };
+
+    const designToVocabularyOptionKeyMap = {
+      gear: {
+        'easy-hard': 'easy-to-hard',
+        'hard-easy': 'hard-to-easy',
+        'quick-wins': 'quick-wins',
+        'deep-dives': 'deep-dives',
+      },
     };
 
     // Vocabulary module + option tabs
@@ -1831,7 +1911,9 @@
       if (!designModuleKey) return null;
       const savedOptionKey = savedSelections[designModuleKey];
       const options = modules[moduleKey]?.options ?? [];
-      return options.some((opt) => opt.key === savedOptionKey) ? savedOptionKey : null;
+      const normalizedOptionKey =
+        designToVocabularyOptionKeyMap[moduleKey]?.[savedOptionKey] ?? savedOptionKey;
+      return options.some((opt) => opt.key === normalizedOptionKey) ? normalizedOptionKey : null;
     };
 
     let activeModule = 'tones';
@@ -1955,6 +2037,87 @@
 
     styleButtons(moduleButtons, activeModule, (btn) => btn.dataset.moduleTab);
     renderOptions();
+
+    const navPanel = document.getElementById('floating-nav');
+    const navCollapseButton = document.querySelector('[data-nav-collapse]');
+    const navExpandButton = document.getElementById('nav-expand');
+
+    if (navPanel && navCollapseButton && navExpandButton) {
+      navCollapseButton.addEventListener('click', () => {
+        navPanel.classList.add('hidden');
+        navExpandButton.classList.remove('hidden');
+        navCollapseButton.setAttribute('aria-expanded', 'false');
+        navExpandButton.setAttribute('aria-expanded', 'false');
+        navPanel.setAttribute('aria-hidden', 'true');
+      });
+
+      navExpandButton.addEventListener('click', () => {
+        navPanel.classList.remove('hidden');
+        navExpandButton.classList.add('hidden');
+        navCollapseButton.setAttribute('aria-expanded', 'true');
+        navExpandButton.setAttribute('aria-expanded', 'true');
+        navPanel.removeAttribute('aria-hidden');
+      });
+    }
+
+    const promptPanel = document.getElementById('prompt-editor');
+    const promptCollapseButton = document.querySelector('[data-prompt-collapse]');
+    const promptExpandButton = document.getElementById('prompt-expand');
+    const promptInput = document.querySelector('[data-prompt-input]');
+    const copyPromptButton = document.querySelector('[data-copy-prompt]');
+
+    if (promptPanel && promptCollapseButton && promptExpandButton) {
+      promptCollapseButton.addEventListener('click', () => {
+        promptPanel.classList.add('hidden');
+        promptExpandButton.classList.remove('hidden');
+        promptCollapseButton.setAttribute('aria-expanded', 'false');
+        promptExpandButton.setAttribute('aria-expanded', 'false');
+        promptPanel.setAttribute('aria-hidden', 'true');
+      });
+
+      promptExpandButton.addEventListener('click', () => {
+        promptPanel.classList.remove('hidden');
+        promptExpandButton.classList.add('hidden');
+        promptCollapseButton.setAttribute('aria-expanded', 'true');
+        promptExpandButton.setAttribute('aria-expanded', 'true');
+        promptPanel.removeAttribute('aria-hidden');
+      });
+    }
+
+    if (copyPromptButton && promptInput) {
+      const originalCopyText = copyPromptButton.textContent;
+      copyPromptButton.addEventListener('click', async () => {
+        const textToCopy = promptInput.value;
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(textToCopy);
+          } else {
+            const tempInput = document.createElement('textarea');
+            tempInput.value = textToCopy;
+            tempInput.setAttribute('readonly', '');
+            tempInput.style.position = 'absolute';
+            tempInput.style.left = '-9999px';
+            document.body.appendChild(tempInput);
+            tempInput.select();
+            document.execCommand('copy');
+            document.body.removeChild(tempInput);
+          }
+          copyPromptButton.textContent = 'Copied!';
+          copyPromptButton.classList.add('bg-slate-900', 'text-white');
+          setTimeout(() => {
+            copyPromptButton.textContent = originalCopyText;
+            copyPromptButton.classList.remove('bg-slate-900', 'text-white');
+          }, 2000);
+        } catch (error) {
+          copyPromptButton.textContent = 'Copy Failed';
+          copyPromptButton.classList.add('bg-rose-100', 'text-rose-700');
+          setTimeout(() => {
+            copyPromptButton.textContent = originalCopyText;
+            copyPromptButton.classList.remove('bg-rose-100', 'text-rose-700');
+          }, 2000);
+        }
+      });
+    }
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- populate the tones vocabulary module with detailed entries for each tone option
- render tone vocabulary as styled blocks that mirror the option description panels and support empty states

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68ef02deb814832eaeb60dca18593297