### PR TITLE
Replace cooking energy source option with movies

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
               aria-labelledby="tab-btn-ex2" hidden>
             <div class="border-b border-slate-200 px-6 py-4">
               <h3 class="text-lg font-semibold">Storyteller · Hobbies + Careers · Creative Task · Music +
-                Cooking + Future Skills · Quick Wins</h3>
+                Movies + Future Skills · Quick Wins</h3>
             </div>
             <div class="space-y-3 px-6 py-4 text-sm text-slate-800">
               <p><strong>When guiding me in study mode, please follow these preferences.</strong></p>
@@ -272,7 +272,7 @@
                 real jobs.</p>
               <p><strong>Approach:</strong> Use small creative tasks to let me build or design something that applies
                 the concept.</p>
-              <p><strong>Motivation/Interest:</strong> Draw from music, cooking, and preparing future skills whenever it
+              <p><strong>Motivation/Interest:</strong> Draw from music, movies, and preparing future skills whenever it
                 fits naturally.</p>
               <p><strong>Pacing:</strong> Provide frequent small wins so I feel steady progress.</p>
             </div>
@@ -668,12 +668,12 @@
               'Imagine unlocking a new water level — first learn H₂O, then earn bonus XP by naming its three states!',
           },
           {
-            key: 'cooking',
-            label: 'Cooking',
+            key: 'movies',
+            label: 'Movies',
             description:
-              'Compares learning to recipes — mixing ingredients, following steps, and adjusting for the best result.',
+              'Connects learning topics to film storytelling — character arcs, conflict, setting, and symbolism.',
             example:
-              'Water’s like the base ingredient — it blends flavors, boils pasta, and steams veggies. No recipe works without it!',
+              'In Spirited Away, water marks passage and renewal (the flooded causeway, the bathhouse cleansing). Scientifically, water is H₂O—a polar molecule that dissolves and transports substances, shifting between ice, liquid, and vapor. The film’s water-as-bridge mirrors water’s real role as life’s connector and cleanser.',
           },
           {
             key: 'future-skills',
@@ -968,7 +968,7 @@
           { key: 'sports', label: 'Sports' },
           { key: 'music', label: 'Music' },
           { key: 'gaming', label: 'Gaming' },
-          { key: 'cooking', label: 'Cooking' },
+          { key: 'movies', label: 'Movies' },
           { key: 'future-skills', label: 'Future Skills' },
         ],
       },
@@ -1663,45 +1663,45 @@
             ],
           },
         ],
-        cooking: [
+        movies: [
           {
-            term: 'Recipe-based',
-            easyExplanation: 'following a set of instructions.',
+            term: 'Character Journey',
+            easyExplanation: 'how a character changes or grows during a story',
             examples: [
-              'Connect lessons to recipe-based cooking to show step-by-step processes.',
-              'Use recipe-based analogies to demonstrate following instructions carefully.',
+              'The film shows a powerful character journey from selfishness to kindness.',
+              'Find movies with a character journey that has a strong connection to our learning topic.',
             ],
           },
           {
-            term: 'Measured',
-            easyExplanation: 'using precise amounts.',
+            term: '🧩 Problem-Solving',
+            easyExplanation: 'finding smart ways to fix difficult situations',
             examples: [
-              'Explain concepts using measured ingredients to highlight accuracy.',
-              'Use measured cooking examples to show the importance of precision.',
+              'Good leaders use problem-solving skills to overcome unexpected challenges.',
+              'Find movies that contains problem-solving that can directly linked to our learning topic.',
             ],
           },
           {
-            term: 'Creative culinary',
-            easyExplanation: 'encouraging inventive cooking.',
+            term: '🌍 Context',
+            easyExplanation: 'the time, place, or situation where something happens',
             examples: [
-              'Relate topics to creative culinary experiments to spark interest.',
-              'Use creative culinary scenarios to illustrate experimenting with ideas.',
+              'Understanding the historical context helps viewers appreciate the story more deeply.',
+              'Find movies set in a context that meaningfully connects to our learning topic.',
             ],
           },
           {
-            term: 'Step-by-step',
-            easyExplanation: 'progressing one stage at a time.',
+            term: '⚔️ Conflict',
+            easyExplanation: 'a struggle or disagreement between people, ideas, or forces',
             examples: [
-              'Use step-by-step cooking processes to mirror how to learn new topics.',
-              'Show me step-by-step recipes to parallel learning sequences.',
+              'The movie’s main conflict is between human survival and nature’s power.',
+              'Find movies where the conflict reflects or illustrates our learning topic.',
             ],
           },
           {
-            term: 'Sensory',
-            easyExplanation: 'involving senses like taste and smell.',
+            term: '💡 Symbolism',
+            easyExplanation: 'when objects or events represent bigger ideas or meanings',
             examples: [
-              'Explain ideas with sensory cooking experiences to make learning vivid.',
-              'Use sensory descriptions from cooking to help me remember concepts.',
+              'The rain in the movie uses symbolism to show renewal and emotional release.',
+              'Find movies where our learning topic serves as symbolism.',
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- replace the Energy Source "Cooking" choice with a new Movies option featuring film-storytelling context
- adjust the example prompt combination to mention movies instead of cooking for the updated module selection
- refresh the Energy Source vocabulary entries to cover movie concepts like character journeys, context, conflict, and symbolism

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68efae60bb08832eb920f67b50765b79